### PR TITLE
saved file in unix format

### DIFF
--- a/scripts/set_min_pass.sh
+++ b/scripts/set_min_pass.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+#
 sed -i 's/PASS_MIN_DAYS\t0/PASS_MIN_DAYS\t7/g' /etc/login.defs


### PR DESCRIPTION
looks like the script was saved in windows format and caused an error during execution on the target linux machine. 
--
Started on ....
Failed on ...:
  The command failed with exit code 126
  STDERR:
    sh: /tmp/f0f3e57b-fa2c-4e34-a678-8e461f06cac5/set_min_pass.sh: /bin/bash^M: bad interpreter: No such file or directory
Failed on 1 target: ....
